### PR TITLE
Extracted a reusable function redirectWithComeFrom()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ Changes
 2.0.0a2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Refactored ``zope.pluggableauth.plugins.session.redirectWithComeFrom``
+  into a reusable function.
 
 
 2.0.0a1 (2013-02-21)


### PR DESCRIPTION
This should make the life easier for people writing alternative credentials plugins (e.g. me).

Example usage:

``` python
from zope.pluggableauth.plugins.session import redirectWithComeFrom
...
class MyCredentialsPlugin(Persistent, Contained):
    def challenge(self, request):
        if not IHTTPRequest.providedBy(request):
            return False
        login_url = absoluteURL(getSite(), '@@login.html')
        redirectWithComeFrom(request, login_url)
        return True
```
