### PR TITLE
Fix NameError in idpicker.py on Python 3.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source = src
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ eggs/
 develop-eggs/
 dist/
 parts/
+.coverage
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,23 @@ python:
   - 3.3
   - 3.4
   - 3.5
-  - pypy
-  - pypy3
-install:
-  - pip install tox-travis
+  - 3.6
+  - pypy-5.4.1
 script:
-  - tox
+  - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
+
+after_success:
+  - coveralls
 notifications:
-    email: false
+  email: false
+
+install:
+  - pip install -U pip setuptools
+  - pip install -U coveralls coverage
+  - pip install -U -e ".[test]"
+
+
+cache: pip
+
+before_cache:
+    - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 Changes
 =======
 
-2.1.1 (unreleased)
+2.2.0 (unreleased)
 ------------------
 
-- TBD
+- Add support for Python 3.6.
+
+- Fix a NameError in the idpicker under Python 3.6.
+  See `issue 7 <https://github.com/zopefoundation/zope.pluggableauth/issues/7>`_.
 
 2.1.0 (2016-07-04)
 ------------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include *.txt
 include *.py
 include buildout.cfg
 include tox.ini
+include .travis.yml
+include .coveragerc
 
 recursive-include src *
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
-``zope.pluggableauth``
-======================
+========================
+ ``zope.pluggableauth``
+========================
 
 .. image:: https://travis-ci.org/zopefoundation/zope.pluggableauth.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.pluggableauth

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -28,21 +28,28 @@ def read(*rnames):
     with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
         return f.read()
 
+tests_require = [
+    'zope.testing',
+    'zope.testrunner',
+]
+
 setup(
     name='zope.pluggableauth',
-    version='2.1.1.dev0',
+    version='2.2.0.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
     description='Pluggable Authentication Utility',
     long_description= "\n\n".join((
-            read('README.rst'),
-            read('src', 'zope', 'pluggableauth', 'README.txt'),
-            read('CHANGES.rst'),
-            )),
+        read('README.rst'),
+        read('src', 'zope', 'pluggableauth', 'README.rst'),
+        read('src', 'zope', 'pluggableauth', 'plugins', 'principalfolder.rst'),
+        read('src', 'zope', 'pluggableauth', 'plugins', 'groupfolder.rst'),
+        read('CHANGES.rst'),
+    )),
     url='http://pypi.python.org/pypi/zope.pluggableauth',
     license='ZPL 2.1',
     keywords='zope3 ztk authentication pluggable',
-    classifiers = [
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
@@ -54,18 +61,20 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Topic :: Internet :: WWW/HTTP',
-        'Framework :: Zope3'],
+        'Framework :: Zope3'
+    ],
     packages=find_packages('src'),
-    package_dir = {'': 'src'},
+    package_dir={'': 'src'},
     namespace_packages=['zope'],
-    extras_require=dict(test=[
-            'zope.testing',
-            #'zope.component[test]' # Pulls in ZODB3 right now. :-(
-            ]),
+    extras_require={
+        'test': tests_require,
+    },
     install_requires=[
         'persistent',
         'setuptools',
@@ -83,9 +92,9 @@ setup(
         'zope.session',
         'zope.site',
         'zope.traversing',
-        ],
-    tests_require=['zope.testing'],
+    ],
+    tests_require=tests_require,
     test_suite='zope.pluggableauth.tests.test_suite',
-    include_package_data = True,
-    zip_safe = False,
-    )
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,7 +1,1 @@
-# this is a namespace package
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/zope/pluggableauth/README.rst
+++ b/src/zope/pluggableauth/README.rst
@@ -1,5 +1,6 @@
-Pluggable-Authentication Utility
-================================
+==================================
+ Pluggable-Authentication Utility
+==================================
 
 The Pluggable-Authentication Utility (PAU) provides a framework for
 authenticating principals and associating information with them. It uses
@@ -10,7 +11,7 @@ registered as a utility providing the
 `zope.authentication.interfaces.IAuthentication` interface.
 
 Authentication
---------------
+==============
 
 The primary job of PAU is to authenticate principals. It uses two types of
 plug-ins in its work:
@@ -42,7 +43,7 @@ the principal. Typically, if a subscriber adds data, it should also add
 corresponding interface declarations.
 
 Simple Credentials Plugin
-~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------
 
 To illustrate, we'll create a simple credentials plugin:
 
@@ -67,7 +68,7 @@ As a plugin, MyCredentialsPlugin needs to be registered as a named utility:
   >>> provideUtility(myCredentialsPlugin, name='My Credentials Plugin')
 
 Simple Authenticator Plugin
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 
 Next we'll create a simple authenticator plugin. For our plugin, we'll need
 an implementation of IPrincipalInfo:
@@ -102,7 +103,7 @@ as a named utility:
   >>> provideUtility(myAuthenticatorPlugin, name='My Authenticator Plugin')
 
 Configuring a PAU
-~~~~~~~~~~~~~~~~~
+-----------------
 
 Finally, we'll create the PAU itself:
 
@@ -115,7 +116,7 @@ and configure it with the two plugins:
   >>> pau.authenticatorPlugins = ('My Authenticator Plugin', )
 
 Using the PAU to Authenticate
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 
   >>> from zope.pluggableauth.factories import AuthenticatedPrincipalFactory
   >>> provideAdapter(AuthenticatedPrincipalFactory)
@@ -142,7 +143,7 @@ However, if we provide the proper credentials:
 we get an authenticated principal.
 
 Multiple Authenticator Plugins
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 The PAU works with multiple authenticator plugins. It uses each plugin, in the
 order specified in the PAU's authenticatorPlugins attribute, to authenticate
@@ -193,7 +194,7 @@ The second plugin, however, gets a chance to authenticate if first does not:
   Principal('xyz_white')
 
 Multiple Credentials Plugins
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 
 As with with authenticators, we can specify multiple credentials plugins. To
 illustrate, we'll create a credentials plugin that extracts credentials from
@@ -290,7 +291,7 @@ This highlights PAU's ability to use multiple plugins for authentication:
   cheers!)
 
 Multiple Authenticator Plugins
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 As with the other operations we've seen, the PAU uses multiple plugins to
 find a principal. If the first authenticator plugin can't find the requested
@@ -371,7 +372,7 @@ we get a different principal for ID 'white':
 
 
 Issuing a Challenge
--------------------
+===================
 
 Part of PAU's IAuthentication contract is to challenge the user for
 credentials when its 'unauthorized' method is called. The need for this
@@ -452,7 +453,7 @@ the advanced plugin is used because it's first:
   'advancedlogin.html'
 
 Challenge Protocols
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 Sometimes, we want multiple challengers to work together. For example, the
 HTTP specification allows multiple challenges to be issued in a response. A
@@ -510,7 +511,7 @@ first plugin:
 
 
 Pluggable-Authentication Prefixes
----------------------------------
+=================================
 
 Principal ids are required to be unique system wide. Plugins will often provide
 options for providing id prefixes, so that different sets of plugins provide

--- a/src/zope/pluggableauth/plugins/groupfolder.rst
+++ b/src/zope/pluggableauth/plugins/groupfolder.rst
@@ -1,6 +1,6 @@
-=============
-Group Folders
-=============
+===============
+ Group Folders
+===============
 
 Group folders provide support for groups information stored in the ZODB.  They
 are persistent, and must be contained within the PAUs that use them.
@@ -187,8 +187,7 @@ Groups cannot contain cycles:
   ... # doctest: +NORMALIZE_WHITESPACE
   Traceback (most recent call last):
   ...
-  GroupCycle: (u'auth.group.G2',
-               [u'auth.group.G2', u'auth.group.G1'])
+  zope.pluggableauth.plugins.groupfolder.GroupCycle: (u'auth.group.G2', [u'auth.group.G2', u'auth.group.G1'])
 
 Trying to do so does not fire an event.
 
@@ -236,7 +235,7 @@ If you don't supply a search key, no results will be returned:
   []
 
 Identifying groups
-------------------
+==================
 The function, `setGroupsForPrincipal`, is a subscriber to
 principal-creation events.  It adds any group-folder-defined groups to
 users in those groups:
@@ -266,7 +265,7 @@ function also declares the `IGroup` interface on groups:
   ['IGroupAwarePrincipal']
 
 Special groups
---------------
+==============
 Two special groups, Authenticated, and Everyone may apply to users
 created by the pluggable-authentication utility.  There is a
 subscriber, specialGroups, that will set these groups on any non-group
@@ -345,7 +344,7 @@ And they are only added to group aware principals:
   []
 
 Member-aware groups
--------------------
+===================
 The groupfolder includes a subscriber that gives group principals the
 zope.security.interfaces.IGroupAware interface and an implementation thereof.
 This allows groups to be able to get and set their members.
@@ -397,7 +396,7 @@ The two methods work with the value on the IGroupInformation object.
     True
 
 Limitation
-==========
+----------
 
 The current group-folder design has an important limitation!
 

--- a/src/zope/pluggableauth/plugins/idpicker.py
+++ b/src/zope/pluggableauth/plugins/idpicker.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Helper base class that picks principal ids
 
-$Id: idpicker.py 117492 2010-10-13 08:17:55Z janwijbrand $
 """
 __docformat__ = 'restructuredtext'
 
@@ -23,9 +22,16 @@ from zope.container.contained import NameChooser
 from zope.exceptions.interfaces import UserError
 from zope.i18nmessageid import MessageFactory
 
+try:
+    text_type = unicode
+except NameError: # py3
+    text_type = str
+
 _ = MessageFactory('zope')
 
 ok = re.compile('[!-~]+$').match
+
+
 class IdPicker(NameChooser):
     """Helper base class that picks principal ids.
 
@@ -53,11 +59,11 @@ class IdPicker(NameChooser):
     """
     def chooseName(self, name, object):
         i = 0
-        name = unicode(name)
+        name = text_type(name)
         orig = name
         while (not name) or (name in self.context):
             i += 1
-            name = orig+str(i)
+            name = orig + str(i)
 
         self.checkName(name, object)
         return name
@@ -76,14 +82,14 @@ class IdPicker(NameChooser):
 
         >>> try:
         ...     IdPicker({}).checkName(u'bob\xfa', None)
-        ... except UserError, e:
+        ... except UserError as e:
         ...     print(e)
         ...     # doctest: +NORMALIZE_WHITESPACE
         Ids must contain only printable 7-bit non-space ASCII characters
 
         >>> try:
         ...     IdPicker({}).checkName(u'big bob', None)
-        ... except UserError, e:
+        ... except UserError as e:
         ...     print(e)
         ...     # doctest: +NORMALIZE_WHITESPACE
         Ids must contain only printable 7-bit non-space ASCII characters
@@ -96,7 +102,7 @@ class IdPicker(NameChooser):
         >>> IdPicker({}).checkName(u'x' * 101, None)
         Traceback (most recent call last):
         ...
-        UserError: Ids can't be more than 100 characters long.
+        zope.exceptions.interfaces.UserError: Ids can't be more than 100 characters long.
 
         """
         NameChooser.checkName(self, name, object)

--- a/src/zope/pluggableauth/plugins/principalfolder.rst
+++ b/src/zope/pluggableauth/plugins/principalfolder.rst
@@ -1,6 +1,6 @@
-================
-Principal Folder
-================
+==================
+ Principal Folder
+==================
 
 Principal folders contain principal-information objects that contain principal
 information. We create an internal principal using the `InternalPrincipal`
@@ -19,7 +19,7 @@ and add them to a principal folder:
   >>> principals['p2'] = p2
 
 Authentication
---------------
+==============
 
 Principal folders provide the `IAuthenticatorPlugin` interface. When we
 provide suitable credentials:
@@ -40,7 +40,7 @@ None is returned if the credentials are invalid:
   >>> principals.authenticateCredentials(42)
 
 Search
-------
+======
 
 Principal folders also provide the IQuerySchemaSearch interface.  This
 supports both finding principal information based on their ids:
@@ -130,7 +130,7 @@ If there is a matching principal, the id is returned:
   u'principal.p1'
 
 Changing credentials
---------------------
+====================
 
 Credentials can be changed by modifying principal-information objects:
 
@@ -160,7 +160,7 @@ If such an attempt is made, the data are unchanged:
   PrincipalInfo(u'principal.p1')
 
 Removing principals
--------------------
+===================
 
 Of course, if a principal is removed, we can no-longer authenticate it:
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,9 @@
 [tox]
 envlist =
-    py27,py33,py34,py35
+    py27, pypy, py34, py35, py36
 
 [testenv]
 commands =
-    python setup.py -q test -q
-# without explicit deps, setup.py test will download a bunch of eggs into $PWD
-# (and it seems I can't use zope.dottedname[testing] here, so forget DRY)
+    zope-testrunner --test-path=src []
 deps =
-    persistent
-    setuptools
-    transaction
-    zope.authentication
-    zope.component[test]
-    zope.container>=4.0.0a1
-    zope.event
-    zope.i18n>=4.0.0a4
-    zope.i18nmessageid
-    zope.interface
-    zope.password>=4.0.0
-    zope.publisher>=4.0.0a1
-    zope.schema
-    zope.security>=4.0.0a3
-    zope.session>=4.0.0a1
-    zope.site>=4.0.0a1
-    zope.traversing>=4.0.0a1
+    .[test]


### PR DESCRIPTION
Fixes #7.

There were tests for this, they just weren't being run, so make sure to run them.

Also a number of small updates:

- Run *all* the doctests.
- Enable test coverage reporting.
- Add support for Python 3.6 and explicitly list PyPy in the classifiers too.
- Modernize tox.ini
- Use pip on Travis and enable Travis caching.
- Run all doctests with consistent flags and checker
- Use renormalizing.IGNORE_EXCEPTION_MODULE_IN_PYTHON2 instead of
  manually normalizing one exception
- Rename .txt to .rst and include them in the published docs. Fix
  headers to be consistent to enable this.