### PR TITLE
Fix deprecation warning.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,10 @@
 ==================
 
 - Drop support for Python 3.4.
+
 - Add support for Python 3.7.
+
+- Import from zope.interface.interfaces to avoid deprecation warning.
 
 
 2.3.0 (2017-11-12)

--- a/src/zope/pluggableauth/tests.py
+++ b/src/zope/pluggableauth/tests.py
@@ -19,11 +19,11 @@ import doctest
 import re
 import unittest
 import zope.component
-from zope.component.interfaces import IComponentLookup
 from zope.container.interfaces import ISimpleReadContainer
 from zope.container.traversal import ContainerTraversable
 from zope.interface import implementer
 from zope.interface import Interface
+from zope.interface.interfaces import IComponentLookup
 from zope.pluggableauth.plugins.session import SessionCredentialsPlugin
 from zope.publisher import base
 from zope.publisher.interfaces import IRequest


### PR DESCRIPTION
Import IComponentLookup from zope.interface.interfaces instead of from
zope.component.interfaces.

This closes #15

modified:   CHANGES.rst
modified:   src/zope/pluggableauth/tests.py