### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 5.0 (unreleased)
 ================
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Drop support for Python 3.8.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-4.1 (unreleased)
+5.0 (unreleased)
 ================
 
 - Drop support for Python 3.8.

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ tests_require = [
 
 setup(
     name='zope.pluggableauth',
-    version='4.1.dev0',
+    version='5.0.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
     description='Pluggable Authentication Utility',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@
 
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -34,7 +33,7 @@ def read(*rnames):
 
 tests_require = [
     'zope.testing',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
 ]
 
 setup(
@@ -72,9 +71,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Framework :: Zope :: 3',
     ],
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['zope'],
     python_requires='>=3.9',
     extras_require={
         'test': tests_require,

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
